### PR TITLE
fix injected path of bundle JS (to improve support for SPAs) 

### DIFF
--- a/client/webpack/common.config.js
+++ b/client/webpack/common.config.js
@@ -19,6 +19,9 @@ module.exports = {
 			},
 		],
 	},
+	output: {
+		publicPath: "/",
+	},
 	plugins: [
 		new HtmlWebpackPlugin({
 			favicon: "./client/src/favicon.ico",

--- a/client/webpack/common.config.js
+++ b/client/webpack/common.config.js
@@ -19,15 +19,6 @@ module.exports = {
 			},
 		],
 	},
-
-	devServer: {
-		contentBase: path.resolve("src"),
-		hot: true,
-		open: true,
-		port: 8000,
-		watchContentBase: true,
-		historyApiFallback: true,
-	},
 	plugins: [
 		new HtmlWebpackPlugin({
 			favicon: "./client/src/favicon.ico",


### PR DESCRIPTION
Same fix as in the starter-project here : https://github.com/CodeYourFuture/cyf-final-project-starter-kit/pull/7

PLUS I removed the `devServer` section from `client/webpack/common.config.js` file as that's shared between dev and production, if there's things in there that are really needed to make your project work, then they should be made to the `devServer` section of `client/webpack/dev.config.js`.